### PR TITLE
Strip whitespace from data files

### DIFF
--- a/processGeoIpCsv.py
+++ b/processGeoIpCsv.py
@@ -18,7 +18,7 @@ def removeOldData():
         pass
 
 def jsonify(item):
-    return json.dumps(item).encode('utf-8')
+    return json.dumps(item, separators=(',', ':')).encode('utf-8')
 
 def storeFile(filename, content, binary = False):
     if binary:
@@ -113,9 +113,9 @@ def generateIndexes(ipIndex):
     MID_NODES = int(ceil(len(ipIndex)/ROOT_NODES))
     for i in range(ROOT_NODES):
         rootIpIndex.append(ipIndex[i*MID_NODES])
-        storeFile("i%d.json" % i, json.dumps(ipIndex[i*MID_NODES:(i+1)*MID_NODES]))
+        storeFile("i%d.json" % i, json.dumps(ipIndex[i*MID_NODES:(i+1)*MID_NODES], separators=(',', ':')))
 
-    storeFile("index.json", json.dumps(rootIpIndex))
+    storeFile("index.json", json.dumps(rootIpIndex, separators=(',', ':')))
     return MID_NODES
 
 def storeDynamicParams(location_record_length, num_mid_nodes):

--- a/tests/testCsvProcessing.py
+++ b/tests/testCsvProcessing.py
@@ -47,7 +47,7 @@ def createBlocksFile():
 207.97.192.0/18,6252001,6252001,,0,0,,37.7510,-97.8220,1000
 23.161.144.0/20,,6252001,,0,0,,,,
 80.231.5.0/24,,,,0,1,,,,
-""" + "208.69.72.0/21,,6252001,,0,0,,,,\n"*2000,
+""" + "208.69.72.0/21,,6252001,,0,0,,,,\n"*3000,
     "GeoLite2-City-Blocks-IPv4.csv",
     "raw")
 
@@ -91,6 +91,7 @@ class TestDataGenerator(unittest.TestCase):
         firstIp = geoip.ipStr2Int("207.97.192.0")
         secondBlockIp = geoip.ipStr2Int("208.69.72.0")
         self.assertListEqual(ipIndex, [firstIp, secondBlockIp])
+        self.assertGreaterEqual(len(ipIndex), 2, "Data should be split into at least 2 files")
         for i in range(len(ipIndex)):
             self.assertEqual(readFile("%d.json" % i, "data")[0][0], ipIndex[i])
         firstBlock = readFile("0.json", "data")


### PR DESCRIPTION
Closes #3

The tests are adjusted to produce more data such that the file splitting behavior is still tested, since the whitespace removal actually results in the existing amount of test data fitting in a single file rather than getting split.

With 3003 test records, we see ~15.7% space savings (74.8 KB vs 88.7 KB).

<details>
<summary>AI disclosure: the space savings estimate was a result of this script generated using Claude:</summary>

Script:

<pre lang="python">
#!/usr/bin/env python3
import json

# Sample records from the actual data
test_records = [
    [3479289856, 1, 37.751, -97.822, 1000],
    [3964641280, 1, 0, 0, 0],
    [1357317376, None, 0, 0, 0],
    [3494201344, 1, 0, 0, 0]
]

# OLD: with whitespace (default)
old_json = json.dumps(test_records)
old_size = len(old_json.encode('utf-8'))

# NEW: without whitespace (compact)
new_json = json.dumps(test_records, separators=(',', ':'))
new_size = len(new_json.encode('utf-8'))

print("=" * 60)
print("SAMPLE RECORD COMPARISON (4 records)")
print("=" * 60)
print(f"\nOLD (with whitespace):")
print(f"  Size: {old_size} bytes")
print(f"  Format: {old_json[:80]}...")
print(f"\nNEW (compact):")
print(f"  Size: {new_size} bytes")
print(f"  Format: {new_json[:80]}...")
print(f"\nSavings per 4 records: {old_size - new_size} bytes ({((old_size - new_size) / old_size * 100):.1f}%)")

# Extrapolate for test data
num_test_records = 3003
old_total = (old_size / 4) * num_test_records
new_total = (new_size / 4) * num_test_records

print("\n" + "=" * 60)
print(f"EXTRAPOLATED FOR TEST DATA ({num_test_records:,} records)")
print("=" * 60)
print(f"OLD: {old_total:,.0f} bytes ({old_total/1024:.1f} KB)")
print(f"NEW: {new_total:,.0f} bytes ({new_total/1024:.1f} KB)")
print(f"Savings: {old_total - new_total:,.0f} bytes ({(old_total - new_total)/1024:.1f} KB, {((old_total - new_total) / old_total * 100):.1f}%)")

# File splitting
file_size = 49052
old_files = int(old_total / file_size) + (1 if old_total % file_size else 0)
new_files = int(new_total / file_size) + (1 if new_total % file_size else 0)

print("\n" + "=" * 60)
print("FILE SPLITTING IMPACT")
print("=" * 60)
print(f"File size limit: {file_size:,} bytes")
print(f"OLD: {old_files} file(s)")
print(f"NEW: {new_files} file(s)")

# Real-world GeoIP data estimate (3.5M records)
print("\n" + "=" * 60)
print("ESTIMATED REAL GEOIP DATA (~3.5M records)")
print("=" * 60)
real_records = 3500000
old_real = (old_size / 4) * real_records
new_real = (new_size / 4) * real_records
print(f"OLD: {old_real/1024/1024:.1f} MB")
print(f"NEW: {new_real/1024/1024:.1f} MB")
print(f"Savings: {(old_real - new_real)/1024/1024:.1f} MB ({((old_real - new_real) / old_real * 100):.1f}%)")
</pre>

Results:

<pre>
============================================================
SAMPLE RECORD COMPARISON (4 records)
============================================================

OLD (with whitespace):
  Size: 121 bytes
  Format: [[3479289856, 1, 37.751, -97.822, 1000], [3964641280, 1, 0, 0, 0], [1357317376, ...

NEW (compact):
  Size: 102 bytes
  Format: [[3479289856,1,37.751,-97.822,1000],[3964641280,1,0,0,0],[1357317376,null,0,0,0]...

Savings per 4 records: 19 bytes (15.7%)

============================================================
EXTRAPOLATED FOR TEST DATA (3,003 records)
============================================================
OLD: 90,841 bytes (88.7 KB)
NEW: 76,576 bytes (74.8 KB)
Savings: 14,264 bytes (13.9 KB, 15.7%)

============================================================
FILE SPLITTING IMPACT
============================================================
File size limit: 49,052 bytes
OLD: 2 file(s)
NEW: 2 file(s)

============================================================
ESTIMATED REAL GEOIP DATA (~3.5M records)
============================================================
OLD: 101.0 MB
NEW: 85.1 MB
Savings: 15.9 MB (15.7%)
</pre>
</details>